### PR TITLE
Merge Dev/bugfix writer into Master

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS,PyAAVF/test
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/PyAAVF/model.py
+++ b/PyAAVF/model.py
@@ -23,6 +23,7 @@ specific language governing permissions and limitations under the License.
 """
 
 
+# pylint: disable=useless-object-inheritance
 class AAVF(object):
     '''An iterable AAVF object that contains the metadata from an AAVF file
        and an list of AAVF records.'''
@@ -61,6 +62,7 @@ class AAVF(object):
         return self.__next__()
 
 
+# pylint: disable=useless-object-inheritance
 class _Record(object):
     """ Equivalent to a row in an AAVF file.
         The standard AAVF fields CHROM, GENE, POS, REF, ALT, FILTER, ALT_FREQ,

--- a/PyAAVF/parser.py
+++ b/PyAAVF/parser.py
@@ -52,6 +52,7 @@ _Info = collections.namedtuple('Info', ['id', 'num', 'type', 'desc', 'source',
 _Filter = collections.namedtuple('Filter', ['id', 'desc'])
 
 
+# pylint: disable=useless-object-inheritance
 class _aavfMetadataParser(object):
     '''Parse the metadata in the header of a AAVF file.'''
     def __init__(self):
@@ -119,7 +120,7 @@ class _aavfMetadataParser(object):
         return (match.group('key'), match.group('val'))
 
 
-# pylint: disable=too-many-instance-attributes,too-many-arguments,too-few-public-methods
+# pylint: disable=too-many-instance-attributes,too-few-public-methods,useless-object-inheritance
 class Reader(object):
     """ Reader that can be used for parsing records from AAVF files.
         You must specify file name."""
@@ -311,6 +312,7 @@ class Reader(object):
                 self.column_headers.append(field.strip())
 
 
+# pylint: disable=useless-object-inheritance
 class Writer(object):
     """Writer for AAVF file. You must supply an output stream,
        and an Reader object to use as a template for the AAVF metadata and

--- a/PyAAVF/parser.py
+++ b/PyAAVF/parser.py
@@ -39,7 +39,7 @@ RESERVED_INFO = {
 }
 
 # Metadata lines which are singular
-SINGULAR_METADATA = ['fileformat', 'fileDate', 'reference', 'source']
+SINGULAR_METADATA = ['fileformat', 'fileDate', 'source']
 
 # Conversion between value in file and Python value
 FIELD_COUNTS = {

--- a/PyAAVF/parser.py
+++ b/PyAAVF/parser.py
@@ -133,11 +133,9 @@ class Reader(object):
             raise Exception('You must provide a file name.')
 
         if filename:
-            dirname = os.path.dirname(__file__)
-            the_path = os.path.join(dirname, filename)
-            if os.path.isfile(the_path):
-                self._reader = open(the_path, "r")
-            elif os.path.isdir(the_path):
+            if os.path.isfile(filename):
+                self._reader = open(filename, "r")
+            elif os.path.isdir(filename):
                 raise Exception('File path provided is a directory')
             else:
                 raise Exception('File path provided does not exist.')

--- a/PyAAVF/test/test_parser.py
+++ b/PyAAVF/test/test_parser.py
@@ -182,8 +182,8 @@ class TestReader(object):
                "filedate should be 20180501, metadata is %s" % aavf.metadata
         assert aavf.metadata.get("source") == "myProgramV1.0", \
                "source should be myProgramV1.0, metadata is %s" % aavf.metadata
-        assert aavf.metadata.get("reference") == "hxb2.fas", \
-               "reference should be hxb2.fas, metadata is %s" % aavf.metadata
+        assert aavf.metadata.get("reference") == ["hxb2.fas"], \
+               "reference list should be [hxb2.fas], metadata is %s" % aavf.metadata
         assert aavf.infos
         assert aavf.filters
 

--- a/PyAAVF/utils.py
+++ b/PyAAVF/utils.py
@@ -62,6 +62,7 @@ def walk_together(*readers):
         else:
             min_k = min(next_index_to_key.values())   # move on to next contig
 
+        # pylint: disable=consider-using-set-comprehension
         min_k_idxs = set([i for i, k in next_index_to_key.items() if k == min_k])
         yield [nexts[i] if i in min_k_idxs else None for i in range(len(nexts))]
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ passenv = LANG
 whitelist_externals =
     true
 setenv =
-    {py27,py36}: STATIC_ANALYSIS = --static-analysis
+    {py36}: STATIC_ANALYSIS = --static-analysis
 deps =
     {py27,py36}: -rrequirements_static_analysis.txt
     -rrequirements_test_runner.txt


### PR DESCRIPTION
Allowed absolute and relative path in input filename for Writer when being used in Python interpreter. Disabled pylint warnings that were introduced in recent release version 2.0 and disabled pylint for Python version 2.7 as it is no longer supported by pylint.
Altered output to be correct when an aavf object is passed to the writer with multiple references